### PR TITLE
Always emit even if nil

### DIFF
--- a/src/massdriver/event.go
+++ b/src/massdriver/event.go
@@ -63,7 +63,7 @@ type EventPayloadArtifacts struct {
 type EventPayloadDiagnostic struct {
 	DeploymentId string `json:"deployment_id"`
 	Message      string `json:"error_message"`
-	Details      string `json:"error_details,omitempty"`
+	Details      string `json:"error_details"`
 	Level        string `json:"error_level"`
 }
 


### PR DESCRIPTION
Since this is the API boundary of this service, IMO we should always send the field so the contract remains consistent. We can tell the value is null by the value being null.

Id say for the rest of the event we should do the same, but I dont know if its a backwards compat change (it should be). Changing this since I know we wont have issues since its not implemented yet.