### PR TITLE
Add gitconfig to mark all dirs safe when cloning providers

### DIFF
--- a/Dockerfile.Prov
+++ b/Dockerfile.Prov
@@ -20,6 +20,7 @@ WORKDIR /bundle
 # The script uses some bash features so add it in
 RUN apk add --upgrade --no-cache bash git openssh
 COPY --from=builder /app/scripts/run.sh /usr/local/bin
+COPY --from=builder /app/scripts/safe-gitconfig /root/.gitconfig
 COPY --from=builder /app/yq /usr/local/bin
 COPY --from=builder /app/xo /usr/local/bin
 COPY --from=builder /app/terraform /usr/local/bin

--- a/scripts/safe-gitconfig
+++ b/scripts/safe-gitconfig
@@ -1,0 +1,2 @@
+[safe]
+	directory = *


### PR DESCRIPTION
This stops git from hitting the issue 

```
Could not download module "kms" (kms.tf:1) source code from "git::https://github.com/massdriver-cloud/terraform-modules.git?ref=afe781a": error downloading 'https://github.com/massdriver-cloud/terraform-modules.git?ref=afe781a': /usr/bin/git exited with 128: fatal: detected dubious ownership in repository at '/bundle/src/.terraform/modules/kms'
To add an exception for this directory, call:

	git config --global --add safe.directory /bundle/src/.terraform/modules/kms
```

We are running locally in a container so anywhere we clone is "safe" and trying to change ownership of the mount dir is more problematic on the fly since that is what would need to be done instead. 