### PR TITLE
Fix artifact publish

### DIFF
--- a/cmd/artifact.go
+++ b/cmd/artifact.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"xo/src/artifact"
 	"xo/src/bundle"
@@ -104,6 +105,11 @@ func runArtifactPublish(cmd *cobra.Command, args []string) error {
 		}
 		defer artFile.Close()
 	}
+	artifactBytes, err := io.ReadAll(artFile)
+	if err != nil {
+		log.Error().Err(err).Msg("unable to open artifact file")
+		return err
+	}
 
 	schemasFile, err := os.Open(schemasPath)
 	if err != nil {
@@ -112,7 +118,7 @@ func runArtifactPublish(cmd *cobra.Command, args []string) error {
 	}
 
 	log.Info().Msg("Validating artifact " + field + "...")
-	valid, err := artifact.Validate(field, artFile, schemasFile)
+	valid, err := artifact.Validate(field, artifactBytes, schemasFile)
 	if !valid || err != nil {
 		log.Error().Err(err).Msg("artifact is invalid")
 		return err
@@ -134,7 +140,7 @@ func runArtifactPublish(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	err = artifact.Publish(ctx, mdClient, artFile, &bun, field, artName)
+	err = artifact.Publish(ctx, mdClient, artifactBytes, &bun, field, artName)
 	if err != nil {
 		log.Error().Err(err).Msg("an error occurred while publishing artifact")
 		return err

--- a/src/artifact/publish_test.go
+++ b/src/artifact/publish_test.go
@@ -1,7 +1,6 @@
 package artifact_test
 
 import (
-	"bytes"
 	"context"
 	"testing"
 	"xo/src/artifact"
@@ -18,7 +17,7 @@ func TestPublish(t *testing.T) {
 		bun          bundle.Bundle
 		field        string
 		artifactName string
-		artifact     string
+		artifact     []byte
 		want         string
 	}
 	tests := []testData{
@@ -28,7 +27,7 @@ func TestPublish(t *testing.T) {
 			bun:          bundle.Bundle{Artifacts: map[string]interface{}{"properties": map[string]interface{}{"foobar": map[string]interface{}{"$ref": "massdriver/artifact-type"}}}},
 			field:        "foobar",
 			artifactName: "artName",
-			artifact:     `{"foo":"bar"}`,
+			artifact:     []byte(`{"foo":"bar"}`),
 			want:         `{"metadata":{"timestamp":"2021-01-01 12:00:00.1234","provisioner":"testaform","event_type":"artifact_updated"},"payload":{"deployment_id":"depId","artifact":{"foo":"bar","metadata":{"field":"foobar","provider_resource_id":"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2","type":"massdriver/artifact-type","name":"artName"}}}}`,
 		},
 	}
@@ -39,8 +38,7 @@ func TestPublish(t *testing.T) {
 			massdriver.EventTimeString = func() string { return "2021-01-01 12:00:00.1234" }
 			testClient := testmass.NewMassdriverTestClient(tc.deploymentId)
 
-			input := bytes.NewBuffer([]byte(tc.artifact))
-			err := artifact.Publish(context.TODO(), &testClient.MassClient, input, &tc.bun, tc.field, tc.artifactName)
+			err := artifact.Publish(context.TODO(), &testClient.MassClient, tc.artifact, &tc.bun, tc.field, tc.artifactName)
 			if err != nil {
 				t.Fatalf("%d, unexpected error", err)
 			}

--- a/src/artifact/validate.go
+++ b/src/artifact/validate.go
@@ -13,12 +13,8 @@ type artifactSchema struct {
 	Properties map[string]interface{} `json:"properties"`
 }
 
-func Validate(field string, artifactIn, schemasIn io.Reader) (bool, error) {
+func Validate(field string, artifact []byte, schemasIn io.Reader) (bool, error) {
 
-	artifactBytes, err := io.ReadAll(artifactIn)
-	if err != nil {
-		return false, err
-	}
 	schemaBytes, err := io.ReadAll(schemasIn)
 	if err != nil {
 		return false, err
@@ -35,7 +31,7 @@ func Validate(field string, artifactIn, schemasIn io.Reader) (bool, error) {
 	}
 
 	sl := gojsonschema.NewGoLoader(specificSchema.(map[string]interface{}))
-	dl := gojsonschema.NewBytesLoader(artifactBytes)
+	dl := gojsonschema.NewBytesLoader(artifact)
 
 	return jsonschema.Validate(sl, dl)
 }

--- a/src/artifact/validate_test.go
+++ b/src/artifact/validate_test.go
@@ -12,7 +12,7 @@ func TestValidate(t *testing.T) {
 		name       string
 		field      string
 		schemaPath string
-		artifact   string
+		artifact   []byte
 		want       bool
 	}
 	tests := []testData{
@@ -20,7 +20,7 @@ func TestValidate(t *testing.T) {
 			name:       "pass",
 			field:      "one",
 			schemaPath: "testdata/schema-artifacts.json",
-			artifact:   `{"data":{"foo":{"bar":"baz"}},"specs":{"hello":"world"}}`,
+			artifact:   []byte(`{"data":{"foo":{"bar":"baz"}},"specs":{"hello":"world"}}`),
 			want:       true,
 		},
 	}
@@ -33,9 +33,7 @@ func TestValidate(t *testing.T) {
 			}
 			schemasBuffer := bytes.NewBuffer(schemasBytes)
 
-			artifactBuffer := bytes.NewBufferString(tc.artifact)
-
-			got, err := artifact.Validate(tc.field, artifactBuffer, schemasBuffer)
+			got, err := artifact.Validate(tc.field, tc.artifact, schemasBuffer)
 			if err != nil {
 				t.Fatalf("%d, unexpected error", err)
 			}


### PR DESCRIPTION
Found a bug in `xo artifact publish`.

You can't read an `io.Reader` twice. We read in validate, and then when we tried to read again in publish it was empty.  Instead move the read up to the `cmd`, and just pass the contents to validate and publish.