### PR TITLE
Tweak function to use short package name instead of package-id

### DIFF
--- a/src/massdriver/main.go
+++ b/src/massdriver/main.go
@@ -44,7 +44,7 @@ type Specification struct {
 	ManifestID                string `envconfig:"MANIFEST_ID"`
 	OrganizationID            string `envconfig:"ORGANIZATION_ID" required:"true"`
 	PackageID                 string `envconfig:"PACKAGE_ID" required:"true"`
-	PackageName               string `envconfig:"PACKAGE_NAME"`
+	PackageName               string `envconfig:"PACKAGE_NAME" required:"true"`
 	S3StateBucket             string `envconfig:"S3_STATE_BUCKET" required:"true"`
 	S3StateRegion             string `envconfig:"S3_STATE_REGION" required:"true"`
 	SecretsTableName          string `envconfig:"SECRETS_TABLE_NAME" required:"true"`

--- a/src/provisioners/terraform/backend.go
+++ b/src/provisioners/terraform/backend.go
@@ -142,11 +142,16 @@ func GenerateJSONBackendHTTPConfig(spec *massdriver.Specification, bundleStep st
 
 	httpbb.Username = spec.DeploymentID
 	httpbb.Password = spec.Token
-	httpbb.Address = fmt.Sprintf("https://api.massdriver.cloud/state/%s/%s", spec.PackageID, bundleStep)
+	httpbb.Address = fmt.Sprintf("https://api.massdriver.cloud/state/%s/%s", getPackageNameShort(spec.PackageName), bundleStep)
 	httpbb.LockAddress = httpbb.Address
 	httpbb.UnlockAddress = httpbb.Address
 
 	topBlock := &TopLevelBlock{Terraform: &TerraformBlock{BackendBlock: &BackendBlock{HTTPBackendBlock: httpbb}}}
 
 	return json.MarshalIndent(topBlock, "", "  ")
+}
+
+func getPackageNameShort(packageId string) string {
+	parts := strings.Split(packageId, "-")
+	return strings.Join(parts[:len(parts)-1], "-")
 }

--- a/src/provisioners/terraform/backend_test.go
+++ b/src/provisioners/terraform/backend_test.go
@@ -38,7 +38,7 @@ func TestGenerateJSONBackendHTTPConfig(t *testing.T) {
 	spec := massdriver.Specification{
 		DeploymentID: "depId",
 		Token:        "token",
-		PackageID:    "pkgId",
+		PackageName:  "pkg-id-long-0000",
 	}
 	got, _ := GenerateJSONBackendHTTPConfig(&spec, "step")
 	want := doc(`
@@ -48,9 +48,9 @@ func TestGenerateJSONBackendHTTPConfig(t *testing.T) {
 				"http": {
 					"username": "depId",
 					"password": "token",
-					"address": "https://api.massdriver.cloud/state/pkgId/step",
-					"lock_address": "https://api.massdriver.cloud/state/pkgId/step",
-					"unlock_address": "https://api.massdriver.cloud/state/pkgId/step"
+					"address": "https://api.massdriver.cloud/state/pkg-id-long/step",
+					"lock_address": "https://api.massdriver.cloud/state/pkg-id-long/step",
+					"unlock_address": "https://api.massdriver.cloud/state/pkg-id-long/step"
 				}
 			}
 		}


### PR DESCRIPTION
Technically I already implemented most of this capability in a previous task. This is tweaking it to work with actual runtime parameters.