### PR TITLE
Update MASSDRIVER_URL to only be base URL (no path)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,7 @@
 .PHONY: test
 test:
-	go test ./cmd
-	go test ./src/...
-	go build
-	./xo schema validate --schema=src/jsonschema/testdata/valid-schema.json --document=src/jsonschema/testdata/valid-document.json
-	./xo bundle build ./src/bundle/testdata/bundle.Build/bundle.yaml -o /tmp/test-bundle-build
+	go test ./cmd --cover
+	go test ./src/... --cover
 
 .PHONY: docker.build
 docker.build:

--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -52,7 +52,7 @@ func runBundlePull(cmd *cobra.Command, args []string) error {
 	}
 	defer outFile.Close()
 
-	log.Info().Msg("pulling bundle")
+	log.Info().Msg("pulling bundle...")
 	pullErr := bundle.Pull(ctx, client, outFile)
 	if pullErr != nil {
 		log.Error().Err(pullErr).Msg("an error occurred while pulling bundle")

--- a/src/massdriver/main.go
+++ b/src/massdriver/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"xo/src/api"
 
@@ -16,7 +17,7 @@ import (
 	"github.com/kelseyhightower/envconfig"
 )
 
-var MassdriverURL = "https://api.massdriver.cloud/api/"
+var MassdriverURL = "https://api.massdriver.cloud/"
 
 // EventPublisher will know how to publish an event to a specific target (sns, logs etc.)
 type EventPublisher interface {
@@ -71,7 +72,11 @@ func InitializeMassdriverClient() (*MassdriverClient, error) {
 		client.Specification.URL = MassdriverURL
 	}
 
-	client.GQLCLient = api.NewClient(client.Specification.URL, client.Specification.DeploymentID, client.Specification.Token)
+	graphqlEndpoint, gqlErr := url.JoinPath(client.Specification.URL, "api")
+	if gqlErr != nil {
+		return nil, gqlErr
+	}
+	client.GQLCLient = api.NewClient(graphqlEndpoint, client.Specification.DeploymentID, client.Specification.Token)
 
 	cfg, err := config.LoadDefaultConfig(context.TODO())
 	if err != nil {


### PR DESCRIPTION
This caused an unexpected breakage during a rollout. Updating the code to better reflect naming and conventions to avoid issues in the future.